### PR TITLE
README: Link to issues view

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ We propose that this repository become the canonical channel for communicating n
 
 To take part in the conversation about developing communication strategy - please respond to the issue ["Developing a Transparent and Community-Driven Communications Strategy"](https://github.com/carpentries/conversations/issues/1).  
 
-To start another conversation about a suggestion you have, ask a question about ongoing work, or give feedback about an issue or obstacle you face in the community, please start a new Issue.  
+To start another conversation about a suggestion you have, ask a question about ongoing work, or give feedback about an issue or obstacle you face in the community, please [start a new issue][issues].
 
 As we work to develop a communications strategy, Carpentry staff will actively monitor this repo and follow-up on issues. All decisions about communications will "live" on this repo. If the community-driven process leads to a decision to use a mechanism other than GitHub for facilitating communications, this repo will be retired and communications migrated to a permanent canonical channel.  
+
+[issues]: https://github.com/carpentries/conversations/issues


### PR DESCRIPTION
Make it even more obvious that they should be creating issues in this repo.  We could link straight to [here][1], but linking to the list view gives a subtle hint that the issue the contributor is planning to suggest might already exist.

Also downcase “Issue”.  I'm not sure why it was capitalized before, but it seemed formal/legal that way, and we're trying to be relaxed and welcoming.

[1]: https://github.com/carpentries/conversations/issues/new